### PR TITLE
72hour first timeout

### DIFF
--- a/publite2/pubscript_longturn_6008.serv
+++ b/publite2/pubscript_longturn_6008.serv
@@ -7,7 +7,7 @@ rulesetdir multiplayer
 set maxplayers 80
 set aifill 80
 set timeout 82800
-set first_timeout 172800
+set first_timeout 259200
 
 #geological
 set size 32

--- a/publite2/pubscript_longturn_6008.serv
+++ b/publite2/pubscript_longturn_6008.serv
@@ -16,12 +16,15 @@ set startpos DEFAULT
 #sociological
 set startunits=cccwwwxx
 
+set timeout 82800
+set first_timeout 172800
+
 
 set nationset all
 set compresstype xs
 set allowtake=""
 set autotoggle false
-set timeout 82800
+
 set unitwaittime=36000
 set netwait 150
 set nettimeout 120
@@ -56,8 +59,7 @@ set borders SEE_INSIDE
 
 
 
-metamessage LongTurn-Web-XVII | 1 turn per day | 80 players | 32000 tiles | 50% Land | Join now!
-
+metamessage Longturn Game XVII | 1 turn per day | 80 players | 32000 tiles | 63% Land | Join now!
 
 cmdlevel basic
 

--- a/publite2/pubscript_longturn_6008.serv
+++ b/publite2/pubscript_longturn_6008.serv
@@ -6,6 +6,8 @@ rulesetdir multiplayer
 
 set maxplayers 80
 set aifill 80
+set timeout 82800
+set first_timeout 172800
 
 #geological
 set size 32
@@ -15,9 +17,6 @@ set startpos DEFAULT
 
 #sociological
 set startunits=cccwwwxx
-
-set timeout 82800
-set first_timeout 172800
 
 
 set nationset all


### PR DESCRIPTION
Set first_timeout to 72 hours, corrected metamessage.